### PR TITLE
Feat#21 회원가입 과정 페이지 구현

### DIFF
--- a/src/component/common/InputComponent.tsx
+++ b/src/component/common/InputComponent.tsx
@@ -13,6 +13,7 @@ interface InputProps {
   type: string;
   value?: InputValue;
   onChange?: (ev: InputChangeEvent) => void;
+  warn?: boolean;
 }
 
 export const Input = ({
@@ -21,7 +22,8 @@ export const Input = ({
   minLength = 0,
   type = '',
   value = '',
-  onChange
+  onChange,
+  warn = false
 }: InputProps) => {
   const [show, setShow] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<InputValue>(value);
@@ -33,7 +35,10 @@ export const Input = ({
 
   return (
     <InputContainer>
-      <Title style={FONT.H7}>{label}</Title>
+      <EmailTitle>
+        <Title style={FONT.H7}>{label}</Title>
+        {warn && <Warn style={FONT.L6}>* 사용 가능한 이메일 입니다</Warn>}
+      </EmailTitle>
       <InputBox>
         <StyledInput
           type={type == 'password' ? (show ? 'text' : 'password') : type}
@@ -70,6 +75,13 @@ const Title = styled.div`
   padding-left: 3px;
   text-align: left;
 `;
+const Warn = styled.div`
+  color: ${(props) => props.theme.Blue_Main};
+  margin-bottom: 12px;
+  padding-left: 3px;
+  text-align: left;
+`;
+
 const InputBox = styled.div`
   width: 100%;
   height: 55px;
@@ -102,4 +114,9 @@ const Secret = styled.div`
   &:hover {
     cursor: pointer;
   }
+`;
+const EmailTitle = styled.div`
+  display: flex;
+  gap: 15px;
+  width: 100%;
 `;

--- a/src/component/common/InputComponent.tsx
+++ b/src/component/common/InputComponent.tsx
@@ -32,7 +32,7 @@ export const Input = ({
   };
 
   return (
-    <>
+    <InputContainer>
       <Title style={FONT.H7}>{label}</Title>
       <InputBox>
         <StyledInput
@@ -51,11 +51,18 @@ export const Input = ({
           <></>
         )}
       </InputBox>
-    </>
+    </InputContainer>
   );
 };
 
 export default Input;
+
+const InputContainer = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+`;
 
 const Title = styled.div`
   color: ${(props) => props.theme.Black_Main};

--- a/src/pages/SignUpEmail.tsx
+++ b/src/pages/SignUpEmail.tsx
@@ -12,8 +12,29 @@ const SignUpEmailPage = () => (
 
 export default SignUpEmailPage;
 
+function isValidEmail(email: string) {
+  // 이메일 주소 형식을 확인하는 정규식
+  const emailRegex = /^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$/;
+
+  // 정규식과 일치하는지 확인하여 유효한 이메일인지 여부를 반환
+  return emailRegex.test(email);
+}
+
 const SignUpEmail = () => {
   const [check, setCheck] = useState<boolean>(false);
+  const [email, setEmail] = useState<string>('');
+  const [password, setPassword] = useState<string>('');
+  const [passwordCheck, setPasswordCheck] = useState<string>('');
+  const [warn, setWarn] = useState<boolean>(false);
+
+  const EmailCheck = () => {
+    setWarn(isValidEmail(email));
+  };
+  const NextPageHandler = () => {
+    isValidEmail(email) && password === passwordCheck && check
+      ? console.log('다음 페이지로 이동')
+      : console.log('다음 페이지로 이동 불가');
+  };
   return (
     <>
       <InputBox>
@@ -21,8 +42,11 @@ const SignUpEmail = () => {
           label='이메일 주소'
           type='email'
           placeholder='이메일 주소 입력'
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          warn={warn}
         />
-        <ShortButton>인증</ShortButton>
+        <ShortButton onClick={() => EmailCheck()}>인증</ShortButton>
       </InputBox>
       <Blank />
       <Input
@@ -30,6 +54,8 @@ const SignUpEmail = () => {
         type='password'
         placeholder='비밀번호 입력(6자리 이상)'
         minLength={6}
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
       />
       <Blank />
       <Input
@@ -37,6 +63,8 @@ const SignUpEmail = () => {
         type='password'
         placeholder='비밀번호 확인'
         minLength={6}
+        value={passwordCheck}
+        onChange={(e) => setPasswordCheck(e.target.value)}
       />
 
       <Terms>
@@ -51,7 +79,13 @@ const SignUpEmail = () => {
         동의(필수)
       </TermsUnder>
 
-      <Button>다음</Button>
+      <Button
+        onClick={() => {
+          NextPageHandler();
+        }}
+      >
+        다음
+      </Button>
     </>
   );
 };

--- a/src/pages/SignUpEmail.tsx
+++ b/src/pages/SignUpEmail.tsx
@@ -1,0 +1,112 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Input from '../component/common/InputComponent';
+import AuthContainer from '../component/login/AuthContainer';
+import { ReactComponent as SmallUnCheck } from '../assets/icon/SmallUnCheck.svg';
+import { ReactComponent as SmallCheck } from '../assets/icon/SmallCheck.svg';
+import FONT from '../styles/Font';
+
+const SignUpEmailPage = () => (
+  <AuthContainer title='이메일로 가입하기' component={<SignUpEmail />} />
+);
+
+export default SignUpEmailPage;
+
+const SignUpEmail = () => {
+  const [check, setCheck] = useState<boolean>(false);
+  return (
+    <>
+      <InputBox>
+        <Input
+          label='이메일 주소'
+          type='email'
+          placeholder='이메일 주소 입력'
+        />
+        <ShortButton>인증</ShortButton>
+      </InputBox>
+      <Blank />
+      <Input
+        label='비밀번호'
+        type='password'
+        placeholder='비밀번호 입력(6자리 이상)'
+        minLength={6}
+      />
+      <Blank />
+      <Input
+        label='비밀번호 확인'
+        type='password'
+        placeholder='비밀번호 확인'
+        minLength={6}
+      />
+
+      <Terms>
+        <div style={FONT.L6} onClick={() => setCheck(!check)}>
+          {check ? <SmallCheck /> : <SmallUnCheck />}
+          TODIS 가입 약관에 동의 합니다
+        </div>
+        <div style={FONT.L6}>가입 약관</div>
+      </Terms>
+      <TermsUnder style={FONT.L6}>
+        TODIS 이용약관 (필수), 개인정보취급방침(필수), 이메일 정보 수집
+        동의(필수)
+      </TermsUnder>
+
+      <Button>다음</Button>
+    </>
+  );
+};
+
+const Terms = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 52px;
+  margin-bottom: 16px;
+  > div {
+    color: ${(props) => props.theme.Black_Main};
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    gap: 5px;
+  }
+`;
+const TermsUnder = styled.div`
+  color: ${(props) => props.theme.Gray_01};
+  margin-bottom: 43px;
+`;
+
+const Blank = styled.div`
+  height: 23px;
+`;
+
+const InputBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 6px;
+`;
+
+const ShortButton = styled.button`
+  width: 30%;
+  height: 55px;
+  border-radius: 14px;
+  border: none;
+  background-color: ${(props) => props.theme.Blue_Main};
+  color: #fff;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  margin-top: 28px;
+`;
+
+const Button = styled.button`
+  width: 100%;
+  height: 55px;
+  border: none;
+  border-radius: 14px;
+  background-color: ${(props) => props.theme.Blue_Main};
+  color: #fff;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+`;

--- a/src/pages/SignUpEmail.tsx
+++ b/src/pages/SignUpEmail.tsx
@@ -31,7 +31,10 @@ const SignUpEmail = () => {
     setWarn(isValidEmail(email));
   };
   const NextPageHandler = () => {
-    isValidEmail(email) && password === passwordCheck && check
+    isValidEmail(email) &&
+    password === passwordCheck &&
+    check &&
+    password.length >= 6
       ? console.log('다음 페이지로 이동')
       : console.log('다음 페이지로 이동 불가');
   };

--- a/src/pages/SignUpInfo.tsx
+++ b/src/pages/SignUpInfo.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import styled from 'styled-components';
+import Input from '../component/common/InputComponent';
+import AuthContainer from '../component/login/AuthContainer';
+import FONT from '../styles/Font';
+
+const SignUpInfoPage = () => (
+  <AuthContainer title='마지막 단계에요!' component={<SignUpInfo />} />
+);
+
+export default SignUpInfoPage;
+const SignUpInfo = () => {
+  const [sex, setSex] = useState<number>(0);
+  const [name, setName] = useState<string>('');
+
+  const handleButtonClick = (selectedSex: number) => {
+    setSex(selectedSex);
+  };
+
+  return (
+    <>
+      <Input
+        label='이름'
+        type='text'
+        placeholder='이름 입력'
+        value={name}
+        onChange={(ev) => setName(ev.target.value)}
+      />
+      <Title style={FONT.H7}>성별</Title>
+      <Sex>
+        <GenderButton
+          isSelected={sex === 1}
+          onClick={() => handleButtonClick(1)}
+        >
+          남자
+        </GenderButton>
+        <GenderButton
+          isSelected={sex === 2}
+          onClick={() => handleButtonClick(2)}
+        >
+          여자
+        </GenderButton>
+      </Sex>
+      <Button>가입 완료하기</Button>
+    </>
+  );
+};
+
+const Sex = styled.div`
+  display: flex;
+  justify-content: space-between;
+  margin-top: 20px;
+`;
+const Title = styled.div`
+  color: ${(props) => props.theme.Black_Main};
+  margin-bottom: 12px;
+  padding-left: 3px;
+  text-align: left;
+  margin-top: 23px;
+`;
+const GenderButton = styled.button<{ isSelected: boolean }>`
+  width: 48%;
+  height: 50px;
+  border-radius: 10px;
+  border: none;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+
+  ${(props) =>
+    props.isSelected
+      ? `
+        background-color: ${props.theme.Blue_Main};
+        color: #fff;
+      `
+      : `
+        background-color: ${props.theme.Gray_04};
+        color: ${props.theme.Gray_01};
+      `};
+
+  &:hover {
+    background-color: ${(props) => props.theme.Gray_03};
+  }
+`;
+const Button = styled.button`
+  width: 100%;
+  height: 55px;
+  margin-top: 248px;
+  border: none;
+  border-radius: 14px;
+  background-color: ${(props) => props.theme.Blue_Main};
+  color: #fff;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+`;


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feat#21

## 변경 사항
- 이메일, 비밀번호 입력 페이지 생성
- 각 정보 저장 가능
- 이메일 형식에 안맞는 경우 체크
- 약관 동의, 비밀번호 체크, 이메일 체크가 완료된 경우만 실행하도록 처리

- 이름 성별 페이지 생성
- 각 정보 저장 가능
- 선택된 성별의 색 변경

## 테스트 결과
<img width="1512" alt="스크린샷 2023-07-22 오후 4 07 55" src="https://github.com/Todis-UMC/Todis_web/assets/78204289/18cde434-935b-45c7-af8e-5b4fbb545ebb">

<img width="1512" alt="스크린샷 2023-07-22 오후 4 06 19" src="https://github.com/Todis-UMC/Todis_web/assets/78204289/311ba6d1-f4b0-4214-919f-2ef5c8830f17">


## 주의사항
- 아직 임시 버튼입니다! 색 변경 처리 하지 않았습니다.
- 이동은 아직 구현하지 않았습니다.
- 이메일 사용 가능이 이미 등록된 로그인도 처리해야한다면 서버와 연동 후 처리하겠습니다.