### PR TITLE
Feat#38 회원 탈퇴 페이지 구현

### DIFF
--- a/src/component/common/SmallModal.tsx
+++ b/src/component/common/SmallModal.tsx
@@ -6,21 +6,31 @@ interface ModalProps {
   title: string;
   content: string;
   onClose: () => void;
+  btn?: string; // 버튼 text
+  onStart?: () => void; // 처음으로 이동
 }
 
-const SmallModal = (props: ModalProps) => {
+const SmallModal = ({
+  title = '',
+  content = '',
+  onClose,
+  btn = '확인',
+  onStart
+}: ModalProps) => {
   return (
-    <Container onClick={props.onClose}>
-      <Box>
-        <div style={FONT.H5}>{props.title}</div>
+    <Container onClick={onClose}>
+      <Box
+        onClick={(e: { stopPropagation: () => void }) => e.stopPropagation()}
+      >
+        <div style={FONT.H5}>{title}</div>
         <Content>
-          {props.content.split('<br/>').map((txt) => (
+          {content.split('<br/>').map((txt) => (
             <>
               <div style={FONT.L5}>{txt}</div>
             </>
           ))}
         </Content>
-        <Button>확인</Button>
+        <Button onClick={btn === '처음으로' ? onStart : onClose}>{btn}</Button>
       </Box>
     </Container>
   );

--- a/src/pages/Withdrawal.tsx
+++ b/src/pages/Withdrawal.tsx
@@ -1,0 +1,77 @@
+import React, { useRef, useState } from 'react';
+import styled from 'styled-components';
+import Input from '../component/common/InputComponent';
+import SmallModal from '../component/common/SmallModal';
+import AuthContainer from '../component/login/AuthContainer';
+import FONT from '../styles/Font';
+
+const WithdrawalPage = () => (
+  <AuthContainer title='계정 탈퇴' component={<Withdrawal />} />
+);
+
+export default WithdrawalPage;
+
+export const Withdrawal = () => {
+  const [password, setPassword] = useState<string>('');
+  const [notice, setNotice] = useState<boolean>(false);
+
+  const handleButton = () => {
+    setNotice(true);
+  };
+  const startButton = () => {
+    setNotice(false);
+    window.location.href = '/home'; // 처음(홈)으로 이동
+  };
+  return (
+    <>
+      <Content>계정 탈퇴를 위해 비밀번호를 입력해주세요.</Content>
+      <Input
+        label='비밀번호'
+        type='password'
+        placeholder='비밀번호 입력'
+        value={password}
+        onChange={(ev) => setPassword(ev.target.value)}
+      />
+      <Button onClick={() => handleButton()}>탈퇴하기</Button>
+
+      {notice && (
+        <SmallModal
+          title={'계정 탈퇴 완료'}
+          content={
+            '계정 탈퇴가 완료되었습니다<br/>그 동안 TODIS를 이용해주셔서 감사합니다'
+          }
+          onClose={startButton}
+          btn='처음으로'
+          onStart={startButton}
+        />
+      )}
+    </>
+  );
+};
+
+const Content = styled.div`
+  height: 25px;
+  width: 90%;
+  color: ${(props) => props.theme.Gray_01};
+  margin: 0 auto;
+  margin-bottom: 80px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`;
+const Button = styled.button`
+  width: 100%;
+  height: 55px;
+  margin-top: 22px;
+  margin-bottom: 19px;
+  border: none;
+  border-radius: 14px;
+  background-color: ${(props) => props.theme.Gray_03};
+  color: #fff;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  &:hover {
+    background-color: ${(props) => props.theme.Blue_Main};
+  }
+`;


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가

## 반영 브랜치
feat#38
## 변경 사항
* SmallModal 컴포넌트에 회원탈퇴 페이지를 위한 props 추가하면서 최대한 기존 코드에 영향 안 가도록 조금 수정했습니다.
* 모달창의 '처음으로' 버튼이나 백그라운드 누르면 우선 /home으로 이동되도록 했습니다. 나중에 라우터 설정이 완료되면 수정하도록 하겠습니다.

## 테스트 결과
![스크린샷(366)](https://github.com/Todis-UMC/Todis_web/assets/101581350/2bc38c40-ad84-4481-adaf-1e2a6c5c0569)
![스크린샷(367)](https://github.com/Todis-UMC/Todis_web/assets/101581350/9b55c972-f56a-4c3e-9181-cb040a19593b)

