### PR TITLE
Feat#61 친구 초대 페이지 API 연동

### DIFF
--- a/src/api/Friend.ts
+++ b/src/api/Friend.ts
@@ -1,0 +1,90 @@
+import { request } from './client';
+
+export const getUserDetail = async () => {
+  console.log('사용자 프로필 불러오기:');
+  try {
+    const res = await request.get({
+      url: '/friend/listuser',
+      params: {}
+    });
+    console.log('사용자 프로필 성공', res);
+    return res;
+  } catch (error) {
+    console.error('사용자 프로필 오류:', error);
+    throw error;
+  }
+};
+
+export const getFriendListDetail = async (id: number) => {
+  console.log('친구 목록 불러오기:');
+  try {
+    const res = await request.get({
+      url: '/friend/listdetail?id=' + id,
+      params: { id: id }
+    });
+    console.log('친구 목록 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 목록 오류:', error);
+    throw error;
+  }
+};
+
+export const getFriendList = async (keyword: string | null) => {
+  console.log('친구 검색하기:');
+  try {
+    const res = await request.get({
+      url: '/friend/listsearch?keyword=' + keyword,
+      params: { keyword: keyword }
+    });
+    console.log('친구 검색 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 검색 오류:', error);
+    throw error;
+  }
+};
+export const getFriendList2 = async (keyword: string | null) => {
+  console.log('친구 검색하기:');
+  try {
+    const res = await request.get({
+      url: '/friend/listsearch',
+      params: { keyword: keyword }
+    });
+    console.log('친구 검색 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 검색 오류:', error);
+    throw error;
+  }
+};
+
+export const deleteFriendListDelete = async (friend_email: string) => {
+  console.log('친구 삭제하기:');
+  try {
+    const res = await request.delete({
+      url: '/friend/listdelete?friend_email=' + friend_email,
+      params: { friend_email: friend_email }
+    });
+    console.log('친구 삭제 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 삭제 오류:', error);
+    throw error;
+  }
+};
+
+export const postMyComment = async (comment: string) => {
+  console.log('글쓰기 작성하기:');
+  try {
+    const res = await request.post({
+      url: '/cody/post?Comment=' + comment,
+      params: { comment: comment }
+    });
+    console.log('글쓰기 성공', res);
+    return res;
+  } catch (error) {
+    console.error('글쓰기 오류:', error);
+    throw error;
+  }
+};

--- a/src/api/FriendInvite.ts
+++ b/src/api/FriendInvite.ts
@@ -1,0 +1,61 @@
+import { request } from './client';
+
+export const putFriendAccept = async (request_id: number) => {
+  console.log('친구 수락하기:', request_id);
+  try {
+    const res = await request.put({
+      url: '/friend/accept?request_id=' + request_id,
+      params: { request_id: request_id }
+    });
+    console.log('친구 수락 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 수락 오류:', error);
+    throw error;
+  }
+};
+
+export const postFriendRequest = async (friend_email: string) => {
+  console.log('친구 요청하기:', friend_email);
+  try {
+    const res = await request.post({
+      url: '/friend/request?friend_email=' + friend_email,
+      params: { friend_email: friend_email }
+    });
+    console.log('친구 요청 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 요청 오류:', error);
+    throw error;
+  }
+};
+
+export const getFriendRequestList = async () => {
+  console.log('친구 요청 목록 불러오기:');
+  try {
+    const res = await request.get({
+      url: '/friend/requestlist',
+      params: {}
+    });
+    console.log('친구 요청 목록 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 요청 목록 오류:', error);
+    throw error;
+  }
+};
+
+export const deleteFriendDelete = async (request_id: number) => {
+  console.log('친구 요청 거절하기:');
+  try {
+    const res = await request.delete({
+      url: '/friend/delete?request_id=' + request_id,
+      params: { request_id: request_id }
+    });
+    console.log('친구 거절 성공', res);
+    return res;
+  } catch (error) {
+    console.error('친구 거절 오류:', error);
+    throw error;
+  }
+};

--- a/src/component/friendInvite/FriendRequest.tsx
+++ b/src/component/friendInvite/FriendRequest.tsx
@@ -52,15 +52,27 @@ const FriendRequest = ({ friendEmail, onClose }: ModalProps) => {
         progress: undefined,
         className: 'custom-toast'
       });
-      return;
+    } else {
+      try {
+        const response = await postFriendRequest(friendEmail);
+        if (response.code === 200) {
+          console.log('친구 요청 성공.', response);
+          onClose?.(); // 창 닫기
+        } else if (response.code === 400) {
+          console.log(response.message);
+          toast(response.message, {
+            position: 'bottom-center',
+            autoClose: 1000,
+            hideProgressBar: true,
+            pauseOnHover: false,
+            progress: undefined,
+            className: 'custom-toast2'
+          });
+        }
+      } catch (error) {
+        console.error('친구 요청 보내기 오류:', error);
+      }
     }
-    try {
-      const response = await postFriendRequest(friendEmail);
-      console.log('친구 요청 성공.', response);
-    } catch (error) {
-      console.error('친구 요청 보내기 오류:', error);
-    }
-    onClose?.(); // 창 닫기
   };
 
   return (

--- a/src/component/friendInvite/FriendRequestComponent.tsx
+++ b/src/component/friendInvite/FriendRequestComponent.tsx
@@ -2,32 +2,80 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import FONT from '../../styles/Font';
 import FriendAccept from './FriendAccept';
+import avatar from '../../assets/img/avatar/M_Avatar.png';
+import { deleteFriendDelete, putFriendAccept } from '../../api/FriendInvite';
 
-const FriendRequestList = ({ name }: { name: string }) => {
+const FriendRequestList = ({
+  request_id,
+  name,
+  profileImageUrl
+}: {
+  request_id: number;
+  name: string;
+  profileImageUrl: string;
+}) => {
   // 모달창 애니메이션
   const [isShown, setIsShown] = useState(false);
-
   useEffect(() => {
     if (isShown) {
       const fadeInTimer = setTimeout(() => {
         setIsShown(false);
         console.log('false');
+        window.location.reload(); // 새로고침 실행
       }, 2000);
       return () => clearTimeout(fadeInTimer);
     }
   }, [isShown]);
 
-  const handleClick = () => {
+  const handleAcceptModal = () => {
     setIsShown(true);
     console.log('true');
   };
 
+  // 친구 수락 API 연동(성공)
+  const handleFriendYes = async () => {
+    try {
+      const response = await putFriendAccept(request_id);
+      if (response.success) {
+        console.log('친구 수락 성공:', response.message);
+        handleAcceptModal();
+      } else {
+        console.error('친구 수락 실패:', response.message);
+      }
+    } catch (error) {
+      console.error('친구 수락 오류:', error);
+    }
+  };
+
+  // 친구 거절 API 연동(성공)
+  const handleFriendNo = async () => {
+    try {
+      const response = await deleteFriendDelete(request_id);
+      if (response.success) {
+        console.log('친구 요청 거절 성공:', response.message);
+      } else {
+        console.error('친구 요청 거절 실패:', response.message);
+      }
+    } catch (error) {
+      console.error('친구 요청 거절 오류:', error);
+    }
+    window.location.reload(); // 새로고침 실행
+  };
+
   return (
     <Box>
-      <Profile></Profile>
+      <Profile>
+        {profileImageUrl === null ? (
+          <img src={avatar} />
+        ) : (
+          <img src={profileImageUrl} />
+        )}
+      </Profile>
       <Name>{name}</Name>
-      <No style={FONT.L5}>거절</No>
-      <Yes style={FONT.L5} onClick={handleClick}>
+      <No style={FONT.L5} onClick={handleFriendNo}>
+        거절
+      </No>
+      <Yes style={FONT.L5} onClick={handleFriendYes}>
         수락
       </Yes>
       <hr />
@@ -59,6 +107,17 @@ const Profile = styled.div`
   height: 39px;
   border-radius: 50%;
   background-color: ${(props) => props.theme.SkyBlue_03};
+  overflow: hidden;
+  position: relative;
+  img {
+    position: absolute;
+    top: -5px;
+    left: -8.5px;
+    height: 320%;
+    width: 150%;
+    object-fit: cover;
+    border: 1px solid #111;
+  }
 `;
 
 const Name = styled.div`

--- a/src/pages/FriendInvite.tsx
+++ b/src/pages/FriendInvite.tsx
@@ -135,6 +135,11 @@ const FriendInvite = () => {
           />
         )}
         <RequestText>받은 친구 요청</RequestText>
+        <span id='message' style={FONT.L4}>
+          도착한 친구 요청이 없습니다.
+          <br />
+          친구를 초대해보세요!
+        </span>
         <ListBox>
           {friendRequests.map((request, index) => (
             <FriendRequestComponent
@@ -192,6 +197,14 @@ const MainBox = styled.div`
     top: 42px;
     left: 49px;
     cursor: pointer;
+  }
+  #message {
+    line-height: 20px;
+    width: 437px;
+    height: 181px;
+    position: absolute;
+    top: 486px;
+    left: 71px;
   }
 `;
 const Profile = styled.div`


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가

## 반영 브랜치
feat#61

## 변경 사항
* /friend/invite 페이지에서 확인 가능합니다.
* 친구 요청, 친구 요청 목록, 친구 수락 및 거절 API 연동 완료했습니다.
* 아이디 검색창에 이메일을 입력 후 요청을 누르면 친구요청이 갑니다.
* 존재하지 않는 이메일이거나 이미 요청을 보낸 이메일이라면 보내지지 않습니다.

## 테스트 결과
e@todis.com의 화면
![image](https://github.com/Todis-UMC/Todis_web/assets/101581350/2f8d56ea-adb3-4681-9816-126b70560272)
e@todis.com 가 c@todis.com에게 친구 요청 보냄
![스크린샷 2023-08-18 205420](https://github.com/Todis-UMC/Todis_web/assets/101581350/52a821ba-e3d0-4021-a007-70a9a27e0470)
친구 요청이 온 c@todis.com의 화면
![image](https://github.com/Todis-UMC/Todis_web/assets/101581350/e4e191f5-59ad-4dc0-b64c-4f8d06c46554)


