### PR TITLE
Feat#66 회원 탈퇴 페이지 API 연동

### DIFF
--- a/src/api/User.ts
+++ b/src/api/User.ts
@@ -75,3 +75,18 @@ export const postFindPassword = async (email: string) => {
     throw error;
   }
 };
+
+export const deleteUserLeave = async () => {
+  console.log('회원 탈퇴하기:');
+  try {
+    const res = await request.delete({
+      url: '/user/leave',
+      params: {}
+    });
+    console.log('회원 탈퇴 성공', res);
+    return res;
+  } catch (error) {
+    console.error('회원 탈퇴 오류:', error);
+    throw error;
+  }
+};

--- a/src/pages/Withdrawal.tsx
+++ b/src/pages/Withdrawal.tsx
@@ -4,6 +4,8 @@ import Input from '../component/common/InputComponent';
 import SmallModal from '../component/common/SmallModal';
 import AuthContainer from '../component/login/AuthContainer';
 import FONT from '../styles/Font';
+import { deleteUserLeave, postPasswordCompare } from '../api/User';
+import { ToastContainer, toast } from 'react-toastify';
 
 const WithdrawalPage = () => (
   <AuthContainer title='계정 탈퇴' component={<Withdrawal />} />
@@ -15,8 +17,34 @@ export const Withdrawal = () => {
   const [password, setPassword] = useState<string>('');
   const [notice, setNotice] = useState<boolean>(false);
 
-  const handleButton = () => {
-    setNotice(true);
+  // 회원 탈퇴 API 연동
+  const handleUserLeaveButton = async () => {
+    const data = { password: password };
+    const response = await postPasswordCompare(data);
+
+    if (response.code === 200) {
+      try {
+        const response2 = await deleteUserLeave();
+        if (response2.success) {
+          console.log('회원 탈퇴 성공:', response2.message);
+          localStorage.removeItem('token');
+          setNotice(true);
+        } else {
+          console.error('회원 탈퇴 실패:', response2.message);
+        }
+      } catch (error) {
+        console.error('회원 탈퇴 오류:', error);
+      }
+    } else if (response.code === 400) {
+      toast(response.message, {
+        position: 'bottom-center',
+        autoClose: 1000,
+        hideProgressBar: true,
+        pauseOnHover: false,
+        progress: undefined,
+        className: 'custom-toast1'
+      });
+    }
   };
   const startButton = () => {
     setNotice(false);
@@ -32,7 +60,7 @@ export const Withdrawal = () => {
         value={password}
         onChange={(ev) => setPassword(ev.target.value)}
       />
-      <Button onClick={() => handleButton()}>탈퇴하기</Button>
+      <Button onClick={() => handleUserLeaveButton()}>탈퇴하기</Button>
 
       {notice && (
         <SmallModal
@@ -45,6 +73,7 @@ export const Withdrawal = () => {
           onStart={startButton}
         />
       )}
+      <ToastContainer />
     </>
   );
 };


### PR DESCRIPTION
## PR 타입
- [x] 기능 추가

## 반영 브랜치
feat#66

## 변경 사항
* /user/delete에서 테스트 할 수 있습니다. 
* 비밀번호 확인 후 회원 탈퇴 가능하게 구현하였습니다. 

## 테스트 결과
![image](https://github.com/Todis-UMC/Todis_web/assets/101581350/3d7de975-ad97-4e85-81ba-a9188bc60a95)
